### PR TITLE
New component merge stackblitz

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,6 @@
 * [\#2: 🅰 Angular kicks in](workshop-todo-list/angular-kicks-in.md)
 * [\#3: 📐 Component](workshop-todo-list/component.md)
 * [\#4: ✏ A new component](workshop-todo-list/a-new-component/README.md)
-  * [a. StackBlitz instructions](workshop-todo-list/a-new-component/stackblitz.md)
 * [\#5: 💼 Class](workshop-todo-list/class.md)
 * [\#6: 📥 Property binding](workshop-todo-list/property-binding.md)
 * [\#7: 📤Event binding](workshop-todo-list/event-binding.md)

--- a/workshop-todo-list/a-new-component/README.md
+++ b/workshop-todo-list/a-new-component/README.md
@@ -18,7 +18,7 @@ Press the **Save** button on the toolbar to save your work.
 
 ---
 
-Let's take a look of what the StackBlitz Generator created for us.
+Let's take a look at what the StackBlitz Generator created for us.
 
 It created a new folder called `src/app/input-button-unit`. There are three files there:
 

--- a/workshop-todo-list/a-new-component/README.md
+++ b/workshop-todo-list/a-new-component/README.md
@@ -2,11 +2,21 @@
 
 In this chapter we will write a whole new component. It will allow us to add an item to the todo list. It will be composed of the HTML elements `input` and `button`. We will call it Input-Button-Unit.
 
-{% hint style="info" %}
-**StackBlitz Instructions** ![](../../.gitbook/assets/stackblitz-hint.svg)
+We'll use the StackBlitz's Angular Generator to create the component.
 
-We'll use the Angular Generator to create a component. Follow the instructions on the [StackBlitz instructions](stackblitz.md) page and return here to continue the worksheet.
-{% endhint %}
+Right click on the `app` folder and select **Angular Generator**, then select **Component**.
+
+![StackBlitz Angular Generator](../../.gitbook/assets/stackblitz-generator.png)
+
+A small text input box displays at the top of the middle editor pane. Type `input-button-unit` to create the component.
+
+![Input component name](../../.gitbook/assets/stackblitz-component-name.png)
+
+You now have a new component!
+
+Press the **Save** button on the toolbar to save your work.
+
+---
 
 Let's take a look of what the StackBlitz Generator created for us.
 

--- a/workshop-todo-list/a-new-component/README.md
+++ b/workshop-todo-list/a-new-component/README.md
@@ -2,6 +2,8 @@
 
 In this chapter we will write a whole new component. It will allow us to add an item to the todo list. It will be composed of the HTML elements `input` and `button`. We will call it Input-Button-Unit.
 
+## Instructions to generate a component
+
 We'll use the StackBlitz's Angular Generator to create the component.
 
 Right click on the `app` folder and select **Angular Generator**, then select **Component**.
@@ -16,7 +18,7 @@ You now have a new component!
 
 Press the **Save** button on the toolbar to save your work.
 
----
+## Breakdown what was generated
 
 Let's take a look at what the StackBlitz Generator created for us.
 


### PR DESCRIPTION
I understand where you're going with seperating the stackblitz instructions.
To have a clear distinction of a cli and stackblitz path.

In this particular case, though, the main thread already mentions stackblitz and works from it.

It was confusing to click the instructions, click the link back.
And when i click next, it brings back to the same instructions.

In my opinion, this makes it easier to follow for someone who is still trying to juggle so much information.

Also made a grammar fix.